### PR TITLE
fix json parse for Android 2.3

### DIFF
--- a/src/on_session_storage_repository.ts
+++ b/src/on_session_storage_repository.ts
@@ -31,11 +31,9 @@ module DDD {
         }
 
         resolve(identity: ID): E {
-            var json = JSON.parse(sessionStorage.getItem(identity.getValue()));
-            if (json) {
-                return this.parse(json);
-            }
-            return null;
+            var item = sessionStorage.getItem(identity.getValue());
+            var json = item ? JSON.parse(item) : null;
+            return json ? this.parse(json) : null;
         }
 
         store(entity: E): E {


### PR DESCRIPTION
Android2.3系で`JSON.parse(null)`がエラーで落ちる。
